### PR TITLE
fix: Remove drive colons in paths to prevent write_tags_db error (Windows)

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ require("simple-tag"):setup({
   -- Disable tag key hints (popup in bottom right corner)
   hints_disabled = false, -- (Optional)
 
-  -- linemode order: adjusts icon/text position. Fo example, if you want icon to be on the mose left of linemode then set linemode_order larger than 1000.
+  -- linemode order: adjusts icon/text position. For example, if you want icon to be on the most left of linemode then set linemode_order larger than 1000.
   -- More info: https://github.com/sxyazi/yazi/blob/077faacc9a84bb5a06c5a8185a71405b0cb3dc8a/yazi-plugin/preset/components/linemode.lua#L4-L5
   linemode_order = 500, -- (Optional)
 
@@ -341,7 +341,7 @@ Or you can use `keymap` to replace all other keys
 
     #  ─────────────────────── VISUAL SELECT FILES/FOLDERS BY TAGS: ───────────────────────
 
-    # Avaiable selection actions:
+    # Available selection actions:
     # replace → Replaces the current selection list with files/folders that have the selected tag.
     # unite → Combines the currently selected files/folders with those that have the selected tag.
     # intersect → Keeps only the files/folders that are present in both the current selection and the tagged items.
@@ -358,7 +358,7 @@ Or you can use `keymap` to replace all other keys
 
     # Run action on files/folders by a tag.
     # A tag hint window will show up.
-    # Simply press any tag key to do the folowing action:
+    # Simply press any tag key to do the following action:
     { on = [ "t", "s", "r" ], run = "plugin simple-tag -- replace-select", desc = "replace-select" },
     { on = [ "t", "s", "u" ], run = "plugin simple-tag -- unite-select", desc = "unite-select" },
     { on = [ "t", "s", "i" ], run = "plugin simple-tag -- intersect-select", desc = "intersect-select" },
@@ -369,7 +369,7 @@ Or you can use `keymap` to replace all other keys
 
     # Run action on files/folders by tag(s) with value from input box.
     # A tag hint window will show up.
-    # Simply input tag key(s) to do the folowing action:
+    # Simply input tag key(s) to do the following action:
     { on = [ "t", "s", "R" ], run = "plugin simple-tag -- replace-select --input", desc = "replace-select --input" },
     { on = [ "t", "s", "U" ], run = "plugin simple-tag -- unite-select --input", desc = "unite-select --input" },
     { on = [ "t", "s", "I" ], run = "plugin simple-tag -- intersect-select --input", desc = "intersect-select --input" },
@@ -387,7 +387,7 @@ Or you can use `keymap` to replace all other keys
 ### Customizing the Theme for tag hints window
 
 To modify the tag hints window appearance, edit `.../yazi/theme.toml`:
-You can also use Falvors file instead.
+You can also use Flavors file instead.
 
 ```toml
 

--- a/main.lua
+++ b/main.lua
@@ -98,7 +98,7 @@ local TAG_ACTION = {
 
 	filter = "filter",
 	files_deleted = "files-deleted",
-	files_transfered = "files-transfered",
+	files_transferred = "files-transferred",
 }
 
 local UI_MODE_ORDERED = {
@@ -589,7 +589,7 @@ function M:setup(opts)
 			changed_files[tostring(from)] = tostring(to)
 		end
 		enqueue_task(STATE_KEY.tasks_rename_tags, changed_files)
-		local args = ya.quote(TAG_ACTION.files_transfered)
+		local args = ya.quote(TAG_ACTION.files_transferred)
 		ya.emit("plugin", {
 			self._id,
 			args,
@@ -600,7 +600,7 @@ function M:setup(opts)
 		local changed_files = {}
 		changed_files[tostring(payload.from)] = tostring(payload.to)
 		enqueue_task(STATE_KEY.tasks_rename_tags, changed_files)
-		local args = ya.quote(TAG_ACTION.files_transfered)
+		local args = ya.quote(TAG_ACTION.files_transferred)
 		ya.emit("plugin", {
 			self._id,
 			args,
@@ -613,7 +613,7 @@ function M:setup(opts)
 			changed_files[tostring(from)] = tostring(to)
 		end
 		enqueue_task(STATE_KEY.tasks_rename_tags, changed_files)
-		local args = ya.quote(TAG_ACTION.files_transfered)
+		local args = ya.quote(TAG_ACTION.files_transferred)
 		ya.emit("plugin", {
 			self._id,
 			args,
@@ -982,8 +982,8 @@ function M:entry(job)
 			if new_selected_files == nil then
 				return
 			end
-			local preseve_selected_files = selected_files()
-			set_state(STATE_KEY.preserve_selected_files, preseve_selected_files)
+			local preserve_selected_files = selected_files()
+			set_state(STATE_KEY.preserve_selected_files, preserve_selected_files)
 		else
 			if not inputted_tags then
 				local title = "Select tags"
@@ -1017,9 +1017,9 @@ function M:entry(job)
 					table.insert(new_selected_files, pathJoin(tags_tbl, fname))
 				end
 			end
-			local preseve_selected_files = selected_files()
-			set_state(STATE_KEY.preserve_selected_files, preseve_selected_files)
-			local old_selected_files = tbl_deep_clone(preseve_selected_files)
+			local preserve_selected_files = selected_files()
+			set_state(STATE_KEY.preserve_selected_files, preserve_selected_files)
+			local old_selected_files = tbl_deep_clone(preserve_selected_files)
 			if action == TAG_ACTION.replace_select then
 				-- no needs to do anything else
 			elseif action == TAG_ACTION.unite_select then
@@ -1098,7 +1098,7 @@ function M:entry(job)
 		ya.emit("update_files", { op = fs.op("done", { id = id, url = _cwd, cha = Cha({ kind = 16 }) }) })
 	elseif action == TAG_ACTION.files_deleted then
 		delete_tags()
-	elseif action == TAG_ACTION.files_transfered then
+	elseif action == TAG_ACTION.files_transferred then
 		local changes = dequeue_task(STATE_KEY.tasks_rename_tags)
 		if changes then
 			local changed_tags_db = {}

--- a/main.lua
+++ b/main.lua
@@ -3,10 +3,11 @@
 local PackageName = "simple-tag"
 local M = {}
 
-
 --          ╭─────────────────────────────────────────────────────────╮
 --          │                          ENUM                           │
 --          ╰─────────────────────────────────────────────────────────╯
+
+local TARGET_FAMILY = ya.target_family()
 
 -- stylua: ignore
 local CAND_TAG_KEYS = {
@@ -394,7 +395,8 @@ end)
 ---@return table<{[string]:string[]}
 local function read_tags_tbl(tags_tbl)
 	local save_path = get_state(STATE_KEY.save_path)
-	local tbl_saved_file = pathJoin(save_path, tags_tbl, "tags.json")
+	local tbl = TARGET_FAMILY == "windows" and tags_tbl:gsub(":", "") or tags_tbl
+	local tbl_saved_file = pathJoin(save_path, tbl, "tags.json")
 
 	local file = io.open(tbl_saved_file, "r")
 	if file == nil then
@@ -416,7 +418,8 @@ local function write_tags_db()
 
 	local save_path = get_state(STATE_KEY.save_path)
 	for tags_tbl, tags_tbl_records in pairs(changed_tags_db) do
-		local tags_tbl_save_dir = pathJoin(save_path, tags_tbl)
+		local tbl = TARGET_FAMILY == "windows" and tags_tbl:gsub(":", "") or tags_tbl
+		local tags_tbl_save_dir = pathJoin(save_path, tbl)
 		for fname, tags in pairs(tags_tbl_records) do
 			if #tags == 0 then
 				changed_tags_db[tags_tbl][fname] = nil
@@ -520,7 +523,7 @@ end
 function M:setup(opts)
 	local st = self
 	local save_path = pathJoin(
-		(ya.target_family() == "windows" and os.getenv("APPDATA") .. "\\yazi\\config\\tags")
+		(TARGET_FAMILY == "windows" and os.getenv("APPDATA") .. "\\yazi\\config\\tags")
 			or (os.getenv("HOME") .. "/.config/yazi/tags")
 	)
 	st[STATE_KEY.tasks_write_tags_db] = {}


### PR DESCRIPTION
In Windows, an error occurred in the `write_tags_db` when a tag path contained a colon as part of the drive specification (e.g., 'C:\Users\user\Documents').

This PR modifies to simply remove the colon from the path before it is saved.